### PR TITLE
support deleting/editing loyalty transactions

### DIFF
--- a/app/controllers/spree/admin/loyalty_points_transactions_controller.rb
+++ b/app/controllers/spree/admin/loyalty_points_transactions_controller.rb
@@ -67,7 +67,7 @@ class Spree::Admin::LoyaltyPointsTransactionsController < Spree::Admin::Resource
       if (parent_data.present? && @parent.nil?) || parent_data.blank?
         admin_users_url
       else
-        admin_user_loyalty_points_url(parent)
+        admin_user_loyalty_points_transactions_url(@parent)
       end
     end
 

--- a/app/overrides/add_loyalty_points_to_admin_user_show_page.rb
+++ b/app/overrides/add_loyalty_points_to_admin_user_show_page.rb
@@ -6,7 +6,7 @@ Deface::Override.new(:virtual_path => 'spree/admin/users/show',
     <th><%= Spree.t(:loyalty_points_balance) %></th>
     <td>
       <% if @user.loyalty_points_balance.present? %>
-        <%= link_to Spree::LoyaltyPoints.loyalty_points_format.display(@user, @user.loyalty_points_balance), spree.admin_user_loyalty_points_path(@user) %>
+        <%= link_to Spree::LoyaltyPoints.loyalty_points_format.display(@user, @user.loyalty_points_balance), [:admin, @user, :loyalty_points_transactions] %>
       <% else %>
         <%= 'No loyalty points yet' %>
       <% end %>

--- a/app/views/spree/admin/loyalty_points_transactions/_form.html.erb
+++ b/app/views/spree/admin/loyalty_points_transactions/_form.html.erb
@@ -1,0 +1,47 @@
+<fieldset data-hook="update_loyalty_points">
+
+  <legend align="center"><%= Spree.t(:update_loyalty_points) %></legend>
+
+  <div data-hook="update_loyalty_points_attrs" class="row">
+
+    <div class="four columns">
+      <%= f.field_container :loyalty_points do %>
+        <%= f.label :loyalty_points, Spree.t(:loyalty_points) %> <span class="required">*</span><br />
+      <%= f.text_field :loyalty_points, :class => 'fullwidth title' %>
+      <%= f.error_message_on :loyalty_points %>
+    <% end %>
+    </div>
+
+    <div class="field four columns">
+      <%= f.label :type, Spree.t(:transaction_type) %> <span class="required">*</span><br />
+      <%= f.select :type, options_for_select(Spree::LoyaltyPointsTransaction::CLASS_TO_TRANSACTION_TYPE.invert), {}, :class => 'select2 fullwidth' %>
+      <%= f.error_message_on :type %>
+    </div>
+
+    <div class="field four columns">
+      <%= label_tag nil, Spree.t(:order) %>
+      <%= f.select :source_id, @user.orders.collect {|o| [o.number, o.id]}, {:include_blank => true}, :class => 'select2 fullwidth', :"data-transactions-link" => admin_user_loyalty_points_transactions_path(@user) %>
+      <%= f.hidden_field :source_type, { :value => 'Spree::Order' } %>
+    </div>
+
+  </div>
+
+  <div data-hook="comment_row" class="row">
+
+    <div class="four columns">
+      <%= f.field_container :comment do %>
+        <%= f.label :comment, Spree.t(:comment) %> <span class="required">*</span><br />
+      <%= f.text_area :comment, :class => 'fullwidth' %>
+      <%= f.error_message_on :comment %>
+    <% end %>
+    </div>
+
+  </div>
+
+  <div class="form-buttons filter-actions actions" data-hook="buttons">
+    <%= button Spree.t('actions.update'), 'icon-ok' %>
+    <span class="or"><%= Spree.t(:or) %></span>
+    <%= link_to_with_icon 'icon-remove', Spree.t('actions.cancel'), admin_users_path, :class => 'button' %>
+  </div>
+
+</fieldset>

--- a/app/views/spree/admin/loyalty_points_transactions/edit.html.erb
+++ b/app/views/spree/admin/loyalty_points_transactions/edit.html.erb
@@ -11,6 +11,6 @@
 
 <div id='loyalty-points-order-transactions'></div>
 
-<%= form_for @loyalty_points_transaction, as: :loyalty_points_transaction, url: [:admin, @user, :loyalty_points_transactions] do |f| %>
+<%= form_for @loyalty_points_transaction, as: :loyalty_points_transaction, url: admin_user_loyalty_points_transaction_path(@user.id, @loyalty_points_transaction.id) do |f| %>
   <%= render partial: 'form', locals: { f: f } %>
 <% end %>

--- a/app/views/spree/admin/loyalty_points_transactions/index.html.erb
+++ b/app/views/spree/admin/loyalty_points_transactions/index.html.erb
@@ -7,10 +7,10 @@
     <%= button_link_to Spree.t(:back_to_user_profile), :back, :icon => 'icon-arrow-left', :id => 'admin_user_link' %>
   </li>
   <li>
-    <%= button_link_to Spree.t(:update_loyalty_points), new_admin_user_loyalty_point_path(@user), :icon => 'icon-plus', :id => 'admin_user_new_loyalty_point_link' %>
+    <%= button_link_to Spree.t(:update_loyalty_points), new_admin_user_loyalty_points_transaction_path(@user), :icon => 'icon-plus', :id => 'admin_user_new_loyalty_point_link' %>
   </li>
 <% end %>
 
-<p>Current Balance: <%= Spree::LoyaltyPoints.loyalty_points_format.display(@user, @user.loyalty_points_balance) %></p>
-<%= render partial: 'spree/loyalty_points/transaction_table' %>
-<br />
+  <p>Current Balance: <%= Spree::LoyaltyPoints.loyalty_points_format.display(@user, @user.loyalty_points_balance) %></p>
+  <%= render partial: 'spree/loyalty_points/transaction_table' %>
+  <br />

--- a/app/views/spree/loyalty_points/_transaction_table.html.erb
+++ b/app/views/spree/loyalty_points/_transaction_table.html.erb
@@ -11,6 +11,7 @@
       <th class="loyalty-points-type"><%= Spree.t(:transaction_type) %></th>
       <th class="loyalty-points"><%= Spree.t(:loyalty_points) %></th>
       <th class="loyalty-points-balance"><%= Spree.t(:updated_balance) %></th>
+      <th class="actions"></th>
     </tr>
     </thead>
     <tbody>
@@ -33,6 +34,10 @@
         <td class="loyalty-points-type"><%= loyalty_point_transaction.transaction_type %></td>
         <td class="loyalty-points"><%= Spree::LoyaltyPoints.loyalty_points_format.display(loyalty_point_transaction, loyalty_point_transaction.loyalty_points) %></td>
         <td class="loyalty-points-balance"><%= Spree::LoyaltyPoints.loyalty_points_format.display(loyalty_point_transaction, loyalty_point_transaction.balance) %></td>
+        <td class="actions">
+          <%= link_to_edit [loyalty_point_transaction], :no_text => true %>
+          <%= link_to_delete [loyalty_point_transaction], :no_text => true %>
+        </td>
       </tr>
     <% end %>
     </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Spree::Core::Engine.routes.draw do
 
   namespace :admin do
     resources :users do
-      resources :loyalty_points, only: [:index, :new, :create], controller: 'loyalty_points_transactions' do
+      resources :loyalty_points_transactions,  except: [:show]  do
         get 'order_transactions/:order_id', action: :order_transactions, on: :collection
       end
     end

--- a/spec/controllers/spree/admin/loyalty_points_transactions_controller_spec.rb
+++ b/spec/controllers/spree/admin/loyalty_points_transactions_controller_spec.rb
@@ -100,7 +100,7 @@ describe Spree::Admin::LoyaltyPointsTransactionsController do
         end
 
         it "redirects to admin users loyalty points page" do
-          expect(response).to redirect_to(admin_user_loyalty_points_url(user, default_host))
+          expect(response).to redirect_to(admin_user_loyalty_points_transactions_url(user, default_host))
         end
 
       end
@@ -164,7 +164,7 @@ describe Spree::Admin::LoyaltyPointsTransactionsController do
         end
 
         it "should return admin_users_url" do
-          controller.send(:collection_url).should eq(admin_user_loyalty_points_url(user, default_host))
+          controller.send(:collection_url).should eq(admin_user_loyalty_points_transactions_url(user, default_host))
         end
 
       end


### PR DESCRIPTION
Changed the routing to use the actual object name (loyalty point
tranasaction) in the admin. as its just the admin, removing the extra
_transaction isn't worth the complications in the spree resource
controller

Change-Id: I5b77ec69f2c1ab91c3000ed720daa11804b7c135
