### PR TITLE
credit users with a bottom limit on order completion date

### DIFF
--- a/app/models/concerns/spree/order/loyalty_points.rb
+++ b/app/models/concerns/spree/order/loyalty_points.rb
@@ -25,8 +25,11 @@ module Spree
       end
 
       module ClassMethods
-        def credit_loyalty_points_to_user
-          uncredited_orders.each do |order|
+        def credit_loyalty_points_to_user since=nil
+          orders = uncredited_orders
+          orders = orders.where('`spree_orders`.`completed_at` > ?', since) if since
+
+          orders.each do |order|
             order.award_loyalty_points
           end
         end


### PR DESCRIPTION
credit_loyalty_points_to_user accepts a date, so that no orders before
that date will be credited.

Change-Id: Ifec85ac9f49e8b43da66b9caa63e6dd5f558821d
